### PR TITLE
Spread corrected tests

### DIFF
--- a/React/finger-exercises/ecmascript/01 - spread/index.js
+++ b/React/finger-exercises/ecmascript/01 - spread/index.js
@@ -19,7 +19,6 @@ export function copy(obj) {
   return newObj;
 }
 
-
 export function reverseMerge(...args) {
   const output = [];
   const reverseArgs = args.reverse();

--- a/React/finger-exercises/ecmascript/01 - spread/test.js
+++ b/React/finger-exercises/ecmascript/01 - spread/test.js
@@ -16,7 +16,7 @@ describe('Spread operator', () => {
   it('min returns undefined on no args', () => {
     expect(min()).toBe(undefined);
   });
-  xit('copy can copy objects', () => {
+  it('copy can copy objects', () => {
     const example = { a: 1, b: 2 };
     const copiedExample = copy(example);
 

--- a/React/finger-exercises/ecmascript/01 - spread/test.js
+++ b/React/finger-exercises/ecmascript/01 - spread/test.js
@@ -39,15 +39,15 @@ describe('Spread operator', () => {
     expect(copiedExample).toEqual([]);
   });
   it('reverseMerge returns a new array based on two, but it switches the order of them', () => {
-    expect(reverseMerge([1], [2])).toBe([2, 1]);
-    expect(reverseMerge([1, 1, 1], [3, 2])).toBe([3, 2, 1, 1, 1]);
-    expect(reverseMerge([1, 2], [3, 4, 5])).toBe([3, 4, 5, 1, 2]);
+    expect(reverseMerge([1], [2])).toEqual([2, 1]);
+    expect(reverseMerge([1, 1, 1], [3, 2])).toEqual([3, 2, 1, 1, 1]);
+    expect(reverseMerge([1, 2], [3, 4, 5])).toEqual([3, 4, 5, 1, 2]);
   });
   it('filterAttribs filters \'a\' and \'b\' by default', () => {
-    expect(filterAttribs({ a: 1, b: 2, c: 3 })).toBe({ c: 3 });
-    expect(filterAttribs({ b: 1, a: 2, c: 3 })).toBe({ c: 3 });
+    expect(filterAttribs({ a: 1, b: 2, c: 3 })).toEqual({ c: 3 });
+    expect(filterAttribs({ b: 1, a: 2, c: 3 })).toEqual({ c: 3 });
     expect(filterAttribs({
       b: 1, d: 2, c: 3, e: 1
-    })).toBe({ c: 3, d: 2, e: 1 });
+    })).toEqual({ c: 3, d: 2, e: 1 });
   });
 });


### PR DESCRIPTION
## Summary

Changed the `toBe()` functions for `toEqual()` on the `tests.js` to avoid checking for memory references and instead check for the values of the returned items.

## Trello Card

https://trello.com/c/hDP6tXtn/6-js-stack-ii-ecma-6-7